### PR TITLE
Fix PGlite live query search, add view-based classifier counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Launch the terminal UI for a guided experience:
 gmail-agent
 ```
 
-Navigate with arrow keys, Enter to select, Esc to go back.
+Navigate with arrow keys, Enter to select, esc to go back.
 
 The TUI will guide you through connecting your Gmail account, creating classifiers, syncing emails, and classifying them.
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -4,6 +4,9 @@ exact = true
 
 cache.disable = true
 
+[test]
+coverage = true
+
 [console]
 depth = 4
 

--- a/package.json
+++ b/package.json
@@ -60,5 +60,5 @@
 		"tsc": "tsgo --noEmit 2>&1 | head -50"
 	},
 	"type": "module",
-	"version": "1.0.8"
+	"version": "1.0.9"
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"check:version": "bun scripts/check-version-bump.ts \"$@\"",
 		"db:check": "bun --bun drizzle-kit check",
 		"db:generate": "bun --bun drizzle-kit generate && bun scripts/compile-migration.ts",
-		"dev": "bun --hot run index.tsx",
+		"dev": "bun --watch run index.tsx",
 		"lint": "biome check --write",
 		"npm:package": "bun scripts/generate-npm-packages.ts",
 		"postinstall": "bun scripts/copy-pglite-assets.ts",

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -50,7 +50,11 @@ async function login() {
 	try {
 		const tokens = await startOAuthFlow({
 			clientId: env.GOOGLE_CLIENT_ID,
-			clientSecret: env.GOOGLE_CLIENT_SECRET
+			clientSecret: env.GOOGLE_CLIENT_SECRET,
+			onAuthUrl: (url) => {
+				console.log("Opening browser for Google authorization...");
+				console.log(`If browser doesn't open, visit:\n${url}\n`);
+			}
 		});
 
 		await saveGmailTokens(db, env.USER_ID, {

--- a/src/cli/commands/classifier.ts
+++ b/src/cli/commands/classifier.ts
@@ -3,6 +3,7 @@ import {
 	createClassifier,
 	deleteClassifier,
 	findClassifiersByUserId,
+	getAccountId,
 	getDatabase,
 	updateClassifier
 } from "../../database/connection";
@@ -93,7 +94,15 @@ async function add(args: string[]) {
 	const env = getEnv();
 	const db = await getDatabase(env.DATABASE_URL);
 
+	// Get accountId for foreign key
+	const accountId = await getAccountId(db, env.USER_ID);
+	if (!accountId) {
+		console.error("No account found. Run 'gmail-agent auth connect' first.");
+		process.exit(1);
+	}
+
 	const created = await createClassifier(db, {
+		accountId,
 		description: values.description,
 		labelName: values.label,
 		name: values.name,

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -30,6 +30,7 @@ export const account = pgTable(
 		accessToken: text(),
 		accessTokenExpiresAt: timestamp({ mode: "date" }),
 		accountId: text().notNull(),
+		defaultClassifiersSeeded: boolean().default(false).notNull(),
 		email: text(),
 		name: text(),
 		providerId: text().notNull(),
@@ -54,6 +55,9 @@ export const classifier = pgTable(
 			.notNull()
 			.$default(() => `clf_${v7()}`),
 		...baseDate,
+		accountId: text()
+			.notNull()
+			.references(() => account.id, { onDelete: "cascade" }),
 		description: text().notNull(),
 		enabled: boolean().default(true).notNull(),
 		labelName: text().notNull(),
@@ -74,6 +78,9 @@ export const classificationRun = pgTable("classification_run", {
 		.notNull()
 		.$default(() => `clr_${v7()}`),
 	...baseDate,
+	accountId: text()
+		.notNull()
+		.references(() => account.id, { onDelete: "cascade" }),
 	completedAt: timestamp({ mode: "date" }),
 	emailsClassified: bigint({ mode: "number" }).notNull().default(0),
 	emailsProcessed: bigint({ mode: "number" }).notNull().default(0),
@@ -94,6 +101,9 @@ export const email = pgTable(
 			.notNull()
 			.$default(() => `eml_${v7()}`),
 		...baseDate,
+		accountId: text()
+			.notNull()
+			.references(() => account.id, { onDelete: "cascade" }),
 		archived: boolean().default(false).notNull(),
 		body: text().notNull(),
 		date: timestamp({ mode: "date" }).notNull(),
@@ -125,6 +135,9 @@ export const emailClassification = pgTable(
 			.notNull()
 			.$default(() => `ecl_${v7()}`),
 		...baseDate,
+		accountId: text()
+			.notNull()
+			.references(() => account.id, { onDelete: "cascade" }),
 		classifierId: text().notNull(),
 		classifierName: text().notNull(),
 		confidence: doublePrecision().notNull(),
@@ -156,6 +169,9 @@ export const syncQueue = pgTable(
 			.notNull()
 			.$default(() => `sqe_${v7()}`),
 		...baseDate,
+		accountId: text()
+			.notNull()
+			.references(() => account.id, { onDelete: "cascade" }),
 		gmailId: text().notNull(),
 		lastError: text(),
 		retryCount: bigint({ mode: "number" }).notNull().default(0),

--- a/src/drizzle/0008_overjoyed_caretaker.sql
+++ b/src/drizzle/0008_overjoyed_caretaker.sql
@@ -1,0 +1,11 @@
+ALTER TABLE "account" ADD COLUMN "defaultClassifiersSeeded" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+ALTER TABLE "classification_run" ADD COLUMN "accountId" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "classifier" ADD COLUMN "accountId" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "email" ADD COLUMN "accountId" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "email_classification" ADD COLUMN "accountId" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "sync_queue" ADD COLUMN "accountId" text NOT NULL;--> statement-breakpoint
+ALTER TABLE "classification_run" ADD CONSTRAINT "classification_run_accountId_account_id_fk" FOREIGN KEY ("accountId") REFERENCES "public"."account"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "classifier" ADD CONSTRAINT "classifier_accountId_account_id_fk" FOREIGN KEY ("accountId") REFERENCES "public"."account"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "email" ADD CONSTRAINT "email_accountId_account_id_fk" FOREIGN KEY ("accountId") REFERENCES "public"."account"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "email_classification" ADD CONSTRAINT "email_classification_accountId_account_id_fk" FOREIGN KEY ("accountId") REFERENCES "public"."account"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sync_queue" ADD CONSTRAINT "sync_queue_accountId_account_id_fk" FOREIGN KEY ("accountId") REFERENCES "public"."account"("id") ON DELETE cascade ON UPDATE no action;

--- a/src/drizzle/meta/0008_snapshot.json
+++ b/src/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,786 @@
+{
+	"_meta": {
+		"columns": {},
+		"schemas": {},
+		"tables": {}
+	},
+	"dialect": "postgresql",
+	"enums": {},
+	"id": "83674478-ac0d-4cab-b4cb-42d42c99b2e7",
+	"policies": {},
+	"prevId": "f9884048-dceb-4313-9abe-305957a3bb43",
+	"roles": {},
+	"schemas": {},
+	"sequences": {},
+	"tables": {
+		"public.account": {
+			"checkConstraints": {},
+			"columns": {
+				"accessToken": {
+					"name": "accessToken",
+					"notNull": false,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"accessTokenExpiresAt": {
+					"name": "accessTokenExpiresAt",
+					"notNull": false,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"accountId": {
+					"name": "accountId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"createdAt": {
+					"default": "now()",
+					"name": "createdAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"defaultClassifiersSeeded": {
+					"default": false,
+					"name": "defaultClassifiersSeeded",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "boolean"
+				},
+				"email": {
+					"name": "email",
+					"notNull": false,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"id": {
+					"name": "id",
+					"notNull": true,
+					"primaryKey": true,
+					"type": "text"
+				},
+				"name": {
+					"name": "name",
+					"notNull": false,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"providerId": {
+					"name": "providerId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"refreshToken": {
+					"name": "refreshToken",
+					"notNull": false,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"scope": {
+					"name": "scope",
+					"notNull": false,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"updatedAt": {
+					"default": "now()",
+					"name": "updatedAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"userId": {
+					"name": "userId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"foreignKeys": {},
+			"indexes": {
+				"account_user_provider_idx": {
+					"columns": [
+						{
+							"asc": true,
+							"expression": "userId",
+							"isExpression": false,
+							"nulls": "last"
+						},
+						{
+							"asc": true,
+							"expression": "providerId",
+							"isExpression": false,
+							"nulls": "last"
+						}
+					],
+					"concurrently": false,
+					"isUnique": false,
+					"method": "btree",
+					"name": "account_user_provider_idx",
+					"with": {}
+				}
+			},
+			"isRLSEnabled": false,
+			"name": "account",
+			"policies": {},
+			"schema": "",
+			"uniqueConstraints": {}
+		},
+		"public.classification_run": {
+			"checkConstraints": {},
+			"columns": {
+				"accountId": {
+					"name": "accountId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"completedAt": {
+					"name": "completedAt",
+					"notNull": false,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"createdAt": {
+					"default": "now()",
+					"name": "createdAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"emailsClassified": {
+					"default": 0,
+					"name": "emailsClassified",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "bigint"
+				},
+				"emailsProcessed": {
+					"default": 0,
+					"name": "emailsProcessed",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "bigint"
+				},
+				"id": {
+					"name": "id",
+					"notNull": true,
+					"primaryKey": true,
+					"type": "text"
+				},
+				"startedAt": {
+					"default": "now()",
+					"name": "startedAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"status": {
+					"default": "'running'",
+					"name": "status",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"updatedAt": {
+					"default": "now()",
+					"name": "updatedAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"userId": {
+					"name": "userId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"foreignKeys": {
+				"classification_run_accountId_account_id_fk": {
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"name": "classification_run_accountId_account_id_fk",
+					"onDelete": "cascade",
+					"onUpdate": "no action",
+					"tableFrom": "classification_run",
+					"tableTo": "account"
+				}
+			},
+			"indexes": {},
+			"isRLSEnabled": false,
+			"name": "classification_run",
+			"policies": {},
+			"schema": "",
+			"uniqueConstraints": {}
+		},
+		"public.classifier": {
+			"checkConstraints": {},
+			"columns": {
+				"accountId": {
+					"name": "accountId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"createdAt": {
+					"default": "now()",
+					"name": "createdAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"description": {
+					"name": "description",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"enabled": {
+					"default": true,
+					"name": "enabled",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "boolean"
+				},
+				"id": {
+					"name": "id",
+					"notNull": true,
+					"primaryKey": true,
+					"type": "text"
+				},
+				"labelName": {
+					"name": "labelName",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"name": {
+					"name": "name",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"priority": {
+					"default": 0,
+					"name": "priority",
+					"notNull": false,
+					"primaryKey": false,
+					"type": "bigint"
+				},
+				"updatedAt": {
+					"default": "now()",
+					"name": "updatedAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"userId": {
+					"name": "userId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"foreignKeys": {
+				"classifier_accountId_account_id_fk": {
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"name": "classifier_accountId_account_id_fk",
+					"onDelete": "cascade",
+					"onUpdate": "no action",
+					"tableFrom": "classifier",
+					"tableTo": "account"
+				}
+			},
+			"indexes": {
+				"classifier_user_idx": {
+					"columns": [
+						{
+							"asc": true,
+							"expression": "userId",
+							"isExpression": false,
+							"nulls": "last"
+						}
+					],
+					"concurrently": false,
+					"isUnique": false,
+					"method": "btree",
+					"name": "classifier_user_idx",
+					"with": {}
+				}
+			},
+			"isRLSEnabled": false,
+			"name": "classifier",
+			"policies": {},
+			"schema": "",
+			"uniqueConstraints": {}
+		},
+		"public.email": {
+			"checkConstraints": {},
+			"columns": {
+				"accountId": {
+					"name": "accountId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"archived": {
+					"default": false,
+					"name": "archived",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "boolean"
+				},
+				"body": {
+					"name": "body",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"createdAt": {
+					"default": "now()",
+					"name": "createdAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"date": {
+					"name": "date",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"from": {
+					"name": "from",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"gmailId": {
+					"name": "gmailId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"id": {
+					"name": "id",
+					"notNull": true,
+					"primaryKey": true,
+					"type": "text"
+				},
+				"labels": {
+					"default": "'{}'",
+					"name": "labels",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text[]"
+				},
+				"snippet": {
+					"name": "snippet",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"subject": {
+					"name": "subject",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"threadId": {
+					"name": "threadId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"to": {
+					"name": "to",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"unread": {
+					"default": false,
+					"name": "unread",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "boolean"
+				},
+				"updatedAt": {
+					"default": "now()",
+					"name": "updatedAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"userId": {
+					"name": "userId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"foreignKeys": {
+				"email_accountId_account_id_fk": {
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"name": "email_accountId_account_id_fk",
+					"onDelete": "cascade",
+					"onUpdate": "no action",
+					"tableFrom": "email",
+					"tableTo": "account"
+				}
+			},
+			"indexes": {
+				"email_gmail_id_idx": {
+					"columns": [
+						{
+							"asc": true,
+							"expression": "gmailId",
+							"isExpression": false,
+							"nulls": "last"
+						}
+					],
+					"concurrently": false,
+					"isUnique": false,
+					"method": "btree",
+					"name": "email_gmail_id_idx",
+					"with": {}
+				},
+				"email_user_date_idx": {
+					"columns": [
+						{
+							"asc": true,
+							"expression": "userId",
+							"isExpression": false,
+							"nulls": "last"
+						},
+						{
+							"asc": true,
+							"expression": "date",
+							"isExpression": false,
+							"nulls": "last"
+						}
+					],
+					"concurrently": false,
+					"isUnique": false,
+					"method": "btree",
+					"name": "email_user_date_idx",
+					"with": {}
+				}
+			},
+			"isRLSEnabled": false,
+			"name": "email",
+			"policies": {},
+			"schema": "",
+			"uniqueConstraints": {
+				"email_gmailId_unique": {
+					"columns": ["gmailId"],
+					"name": "email_gmailId_unique",
+					"nullsNotDistinct": false
+				}
+			}
+		},
+		"public.email_classification": {
+			"checkConstraints": {},
+			"columns": {
+				"accountId": {
+					"name": "accountId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"classifierId": {
+					"name": "classifierId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"classifierName": {
+					"name": "classifierName",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"confidence": {
+					"name": "confidence",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "double precision"
+				},
+				"createdAt": {
+					"default": "now()",
+					"name": "createdAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"emailId": {
+					"name": "emailId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"gmailId": {
+					"name": "gmailId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"id": {
+					"name": "id",
+					"notNull": true,
+					"primaryKey": true,
+					"type": "text"
+				},
+				"labelApplied": {
+					"default": false,
+					"name": "labelApplied",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "boolean"
+				},
+				"labelName": {
+					"name": "labelName",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"reasoning": {
+					"name": "reasoning",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"runId": {
+					"name": "runId",
+					"notNull": false,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"updatedAt": {
+					"default": "now()",
+					"name": "updatedAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"userId": {
+					"name": "userId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"foreignKeys": {
+				"email_classification_accountId_account_id_fk": {
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"name": "email_classification_accountId_account_id_fk",
+					"onDelete": "cascade",
+					"onUpdate": "no action",
+					"tableFrom": "email_classification",
+					"tableTo": "account"
+				}
+			},
+			"indexes": {
+				"email_classification_email_idx": {
+					"columns": [
+						{
+							"asc": true,
+							"expression": "emailId",
+							"isExpression": false,
+							"nulls": "last"
+						}
+					],
+					"concurrently": false,
+					"isUnique": false,
+					"method": "btree",
+					"name": "email_classification_email_idx",
+					"with": {}
+				},
+				"email_classification_gmail_idx": {
+					"columns": [
+						{
+							"asc": true,
+							"expression": "gmailId",
+							"isExpression": false,
+							"nulls": "last"
+						}
+					],
+					"concurrently": false,
+					"isUnique": false,
+					"method": "btree",
+					"name": "email_classification_gmail_idx",
+					"with": {}
+				},
+				"email_classification_user_idx": {
+					"columns": [
+						{
+							"asc": true,
+							"expression": "userId",
+							"isExpression": false,
+							"nulls": "last"
+						}
+					],
+					"concurrently": false,
+					"isUnique": false,
+					"method": "btree",
+					"name": "email_classification_user_idx",
+					"with": {}
+				}
+			},
+			"isRLSEnabled": false,
+			"name": "email_classification",
+			"policies": {},
+			"schema": "",
+			"uniqueConstraints": {
+				"email_classification_emailId_classifierId_unique": {
+					"columns": ["emailId", "classifierId"],
+					"name": "email_classification_emailId_classifierId_unique",
+					"nullsNotDistinct": false
+				}
+			}
+		},
+		"public.sync_queue": {
+			"checkConstraints": {},
+			"columns": {
+				"accountId": {
+					"name": "accountId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"createdAt": {
+					"default": "now()",
+					"name": "createdAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"gmailId": {
+					"name": "gmailId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"id": {
+					"name": "id",
+					"notNull": true,
+					"primaryKey": true,
+					"type": "text"
+				},
+				"lastError": {
+					"name": "lastError",
+					"notNull": false,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"retryCount": {
+					"default": 0,
+					"name": "retryCount",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "bigint"
+				},
+				"status": {
+					"default": "'pending'",
+					"name": "status",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				},
+				"syncedAt": {
+					"name": "syncedAt",
+					"notNull": false,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"updatedAt": {
+					"default": "now()",
+					"name": "updatedAt",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "timestamp"
+				},
+				"userId": {
+					"name": "userId",
+					"notNull": true,
+					"primaryKey": false,
+					"type": "text"
+				}
+			},
+			"compositePrimaryKeys": {},
+			"foreignKeys": {
+				"sync_queue_accountId_account_id_fk": {
+					"columnsFrom": ["accountId"],
+					"columnsTo": ["id"],
+					"name": "sync_queue_accountId_account_id_fk",
+					"onDelete": "cascade",
+					"onUpdate": "no action",
+					"tableFrom": "sync_queue",
+					"tableTo": "account"
+				}
+			},
+			"indexes": {
+				"sync_queue_gmail_id_idx": {
+					"columns": [
+						{
+							"asc": true,
+							"expression": "gmailId",
+							"isExpression": false,
+							"nulls": "last"
+						}
+					],
+					"concurrently": false,
+					"isUnique": false,
+					"method": "btree",
+					"name": "sync_queue_gmail_id_idx",
+					"with": {}
+				},
+				"sync_queue_user_status_idx": {
+					"columns": [
+						{
+							"asc": true,
+							"expression": "userId",
+							"isExpression": false,
+							"nulls": "last"
+						},
+						{
+							"asc": true,
+							"expression": "status",
+							"isExpression": false,
+							"nulls": "last"
+						}
+					],
+					"concurrently": false,
+					"isUnique": false,
+					"method": "btree",
+					"name": "sync_queue_user_status_idx",
+					"with": {}
+				}
+			},
+			"isRLSEnabled": false,
+			"name": "sync_queue",
+			"policies": {},
+			"schema": "",
+			"uniqueConstraints": {
+				"sync_queue_gmailId_userId_unique": {
+					"columns": ["gmailId", "userId"],
+					"name": "sync_queue_gmailId_userId_unique",
+					"nullsNotDistinct": false
+				}
+			}
+		}
+	},
+	"version": "7",
+	"views": {}
+}

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -56,6 +56,13 @@
 			"tag": "0007_new_colossus",
 			"version": "7",
 			"when": 1765380594349
+		},
+		{
+			"breakpoints": true,
+			"idx": 8,
+			"tag": "0008_overjoyed_caretaker",
+			"version": "7",
+			"when": 1765427527313
 		}
 	],
 	"version": "7"

--- a/src/drizzle/migrations.json
+++ b/src/drizzle/migrations.json
@@ -73,5 +73,23 @@
 			"ALTER TABLE \"account\" ADD COLUMN \"email\" text;",
 			"\nALTER TABLE \"account\" ADD COLUMN \"name\" text;"
 		]
+	},
+	{
+		"bps": true,
+		"folderMillis": 1765427527313,
+		"hash": "e628c9052747cc348c900e4087b80216803da40a9ff53d2a51254a60fa7c571d",
+		"sql": [
+			"ALTER TABLE \"account\" ADD COLUMN \"defaultClassifiersSeeded\" boolean DEFAULT false NOT NULL;",
+			"\nALTER TABLE \"classification_run\" ADD COLUMN \"accountId\" text NOT NULL;",
+			"\nALTER TABLE \"classifier\" ADD COLUMN \"accountId\" text NOT NULL;",
+			"\nALTER TABLE \"email\" ADD COLUMN \"accountId\" text NOT NULL;",
+			"\nALTER TABLE \"email_classification\" ADD COLUMN \"accountId\" text NOT NULL;",
+			"\nALTER TABLE \"sync_queue\" ADD COLUMN \"accountId\" text NOT NULL;",
+			"\nALTER TABLE \"classification_run\" ADD CONSTRAINT \"classification_run_accountId_account_id_fk\" FOREIGN KEY (\"accountId\") REFERENCES \"public\".\"account\"(\"id\") ON DELETE cascade ON UPDATE no action;",
+			"\nALTER TABLE \"classifier\" ADD CONSTRAINT \"classifier_accountId_account_id_fk\" FOREIGN KEY (\"accountId\") REFERENCES \"public\".\"account\"(\"id\") ON DELETE cascade ON UPDATE no action;",
+			"\nALTER TABLE \"email\" ADD CONSTRAINT \"email_accountId_account_id_fk\" FOREIGN KEY (\"accountId\") REFERENCES \"public\".\"account\"(\"id\") ON DELETE cascade ON UPDATE no action;",
+			"\nALTER TABLE \"email_classification\" ADD CONSTRAINT \"email_classification_accountId_account_id_fk\" FOREIGN KEY (\"accountId\") REFERENCES \"public\".\"account\"(\"id\") ON DELETE cascade ON UPDATE no action;",
+			"\nALTER TABLE \"sync_queue\" ADD CONSTRAINT \"sync_queue_accountId_account_id_fk\" FOREIGN KEY (\"accountId\") REFERENCES \"public\".\"account\"(\"id\") ON DELETE cascade ON UPDATE no action;"
+		]
 	}
 ]

--- a/src/gmail/oauth.ts
+++ b/src/gmail/oauth.ts
@@ -19,6 +19,7 @@ export interface OAuthTokens {
 export async function startOAuthFlow(config: {
 	clientId: string;
 	clientSecret: string;
+	onAuthUrl?: (url: string) => void;
 }): Promise<OAuthTokens> {
 	return await new Promise((resolve, reject) => {
 		const server = createServer();
@@ -41,8 +42,8 @@ export async function startOAuthFlow(config: {
 				scope: SCOPES
 			});
 
-			console.log("\nOpening browser for Google authorization...");
-			console.log(`If browser doesn't open, visit:\n${authUrl}\n`);
+			// Notify caller of the auth URL (for UI display)
+			config.onAuthUrl?.(authUrl);
 
 			// Open browser (cross-platform)
 			const open = await import("open");

--- a/src/ui/components/ClassificationGrid.tsx
+++ b/src/ui/components/ClassificationGrid.tsx
@@ -171,7 +171,7 @@ export function ClassificationGrid({
 
 			{/* Scroll indicator and instructions */}
 			<Box justifyContent="space-between" marginTop={1}>
-				<Text dimColor>↑/↓ to scroll • Esc to continue in background</Text>
+				<Text dimColor>↑/↓ to scroll • esc to continue in background</Text>
 				{totalRows > visibleRows && (
 					<Text dimColor>
 						{String(scrollOffset + 1)}-

--- a/src/ui/hooks/useLiveQuery.ts
+++ b/src/ui/hooks/useLiveQuery.ts
@@ -47,6 +47,9 @@ export function useLiveQuery<T>(
 		const db = sql as PGliteWithLive;
 		let mounted = true;
 
+		// Parse params at the start of effect to ensure consistency
+		const currentParams = JSON.parse(paramsKey) as unknown[];
+
 		const subscribe = async () => {
 			try {
 				// Unsubscribe from previous query if exists
@@ -74,16 +77,12 @@ export function useLiveQuery<T>(
 						callback,
 						limit: options.limit,
 						offset: options.offset ?? 0,
-						params: JSON.parse(paramsKey),
+						params: currentParams,
 						query
 					});
 				} else {
 					// Use simple query
-					result = await db.live.query<T>(
-						query,
-						JSON.parse(paramsKey),
-						callback
-					);
+					result = await db.live.query<T>(query, currentParams, callback);
 				}
 
 				unsubscribeRef.current = result.unsubscribe;

--- a/src/ui/screens/ClassifierAddScreen.tsx
+++ b/src/ui/screens/ClassifierAddScreen.tsx
@@ -6,7 +6,7 @@ import {
 	type GeneratedClassifier,
 	generateClassifierFromPrompt
 } from "../../ai/classifier-generator.js";
-import { createClassifier } from "../../database/connection.js";
+import { createClassifier, getAccountId } from "../../database/connection.js";
 import { getEnv } from "../../env.js";
 import { Header } from "../components/Header.js";
 import { Spinner } from "../components/Spinner.js";
@@ -67,7 +67,12 @@ export function ClassifierAddScreen() {
 
 		try {
 			const env = getEnv();
+			const accountId = await getAccountId(db, env.USER_ID);
+			if (!accountId) {
+				throw new Error("No account found. Please connect Gmail first.");
+			}
 			await createClassifier(db, {
+				accountId,
 				description: generated.description,
 				labelName: generated.labelName,
 				name: generated.name,
@@ -151,7 +156,7 @@ export function ClassifierAddScreen() {
 
 				<Box marginTop={1}>
 					<Text dimColor>
-						Press Enter to generate classifier, Esc to cancel
+						Press Enter to generate classifier, esc to cancel
 					</Text>
 				</Box>
 			</Box>
@@ -193,7 +198,7 @@ export function ClassifierAddScreen() {
 					</Box>
 
 					<Box marginTop={1}>
-						<Text dimColor>Press Enter to save, Esc to cancel</Text>
+						<Text dimColor>Press Enter to save, esc to cancel</Text>
 					</Box>
 				</Box>
 			);
@@ -271,7 +276,7 @@ export function ClassifierAddScreen() {
 				/>
 
 				<Box marginTop={1}>
-					<Text dimColor>Press Esc to go back to prompt</Text>
+					<Text dimColor>Press esc to go back to prompt</Text>
 				</Box>
 			</Box>
 		);
@@ -304,7 +309,7 @@ export function ClassifierAddScreen() {
 				<Header title="Add Classifier" />
 				<Text color="red">Error: {error}</Text>
 				<Box marginTop={1}>
-					<Text dimColor>Press Esc to go back</Text>
+					<Text dimColor>Press esc to go back</Text>
 				</Box>
 			</Box>
 		);

--- a/src/ui/screens/ClassifiersScreen.tsx
+++ b/src/ui/screens/ClassifiersScreen.tsx
@@ -28,6 +28,7 @@ export function ClassifiersScreen() {
 	// Live query for classifiers
 	const { rows: rawClassifiers, loading: isLoading } = useLiveQuery<{
 		id: string;
+		accountId: string;
 		createdAt: Date;
 		updatedAt: Date;
 		description: string;
@@ -45,6 +46,7 @@ export function ClassifiersScreen() {
 	// Transform to Classifier type
 	const classifiers: Classifier[] = useMemo(() => {
 		return rawClassifiers.map((row) => ({
+			accountId: row.accountId,
 			createdAt: row.createdAt,
 			description: row.description,
 			enabled: row.enabled,
@@ -196,7 +198,7 @@ export function ClassifiersScreen() {
 					</Box>
 
 					<Box marginTop={1}>
-						<Text dimColor>Press Enter to save, Esc to cancel</Text>
+						<Text dimColor>Press Enter to save, esc to cancel</Text>
 					</Box>
 				</Box>
 			);
@@ -232,7 +234,7 @@ export function ClassifiersScreen() {
 					/>
 
 					<Box marginTop={1}>
-						<Text dimColor>Press Esc to cancel</Text>
+						<Text dimColor>Press esc to cancel</Text>
 					</Box>
 				</Box>
 			);
@@ -299,7 +301,7 @@ export function ClassifiersScreen() {
 				/>
 
 				<Box marginTop={1}>
-					<Text dimColor>Press Esc to go back</Text>
+					<Text dimColor>Press esc to go back</Text>
 				</Box>
 			</Box>
 		);
@@ -344,7 +346,7 @@ export function ClassifiersScreen() {
 			/>
 
 			<Box marginTop={1}>
-				<Text dimColor>Press Esc to go back</Text>
+				<Text dimColor>Press esc to go back</Text>
 			</Box>
 		</Box>
 	);


### PR DESCRIPTION
Fix PGlite live query search, add view-based classifier counts, fix custom sync

  The major changes were:
  1. Fixed the PGlite format() error with search (using separate params for each ILIKE field)
  2. Classifier counts now filter by current view mode (inbox/unread/archived)
  3. Custom search sync no longer adds automatic date filter
  4. Various UI fixes (dot colors, page size, key bindings)